### PR TITLE
Add copyright notices for pr #21 and 102

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Files modified by dlacher to support predicate logic (https://github.com/h2non/jsonpath-ng/pull/21):
+- jsonpath_ng/ext/filter.py
+- jsonpath_ng/ext/iterable.py
+- jsonpath_ng/ext/parser.py
+- tests/test_jsonpath_rw_ext.py

--- a/NOTICE
+++ b/NOTICE
@@ -3,3 +3,12 @@ Files modified by dlacher to support predicate logic (https://github.com/h2non/j
 - jsonpath_ng/ext/iterable.py
 - jsonpath_ng/ext/parser.py
 - tests/test_jsonpath_rw_ext.py
+
+Files modified by elrandira to support commas for index accesses and steps in slices
+(https://github.com/h2non/jsonpath-ng/pull/102):
+- jsonpath_ng/jsonpath.py
+- jsonpath_ng/parser.py
+- tests/test_create.py
+- tests/test_examples.py
+- tests/test_jsonpath.py
+- tests/test_parser.py

--- a/jsonpath_ng/ext/filter.py
+++ b/jsonpath_ng/ext/filter.py
@@ -10,6 +10,10 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+#
+# NOTICE:
+# modified by dlacher to support predicate logic: https://github.com/h2non/jsonpath-ng/pull/21
+#
 
 import operator
 import re

--- a/jsonpath_ng/ext/iterable.py
+++ b/jsonpath_ng/ext/iterable.py
@@ -10,6 +10,10 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+#
+# NOTICE:
+# modified by dlacher to support predicate logic: https://github.com/h2non/jsonpath-ng/pull/21
+#
 
 import functools
 from .. import This, DatumInContext, JSONPath

--- a/jsonpath_ng/ext/parser.py
+++ b/jsonpath_ng/ext/parser.py
@@ -11,6 +11,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 #
+# NOTICE:
 # modified by dlacher to support predicate logic: https://github.com/h2non/jsonpath-ng/pull/21
 
 from .. import lexer

--- a/jsonpath_ng/ext/parser.py
+++ b/jsonpath_ng/ext/parser.py
@@ -10,6 +10,8 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+#
+# modified by dlacher to support predicate logic: https://github.com/h2non/jsonpath-ng/pull/21
 
 from .. import lexer
 from .. import parser

--- a/jsonpath_ng/jsonpath.py
+++ b/jsonpath_ng/jsonpath.py
@@ -1,3 +1,20 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# NOTICE:
+# modified by elrandira to support commas for index accesses and steps in slices
+# https://github.com/h2non/jsonpath-ng/pull/102
+
 from __future__ import unicode_literals, print_function, absolute_import, division, generators, nested_scopes
 import logging
 import six

--- a/jsonpath_ng/parser.py
+++ b/jsonpath_ng/parser.py
@@ -1,3 +1,20 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# NOTICE:
+# modified by elrandira to support commas for index accesses and steps in slices
+# https://github.com/h2non/jsonpath-ng/pull/102
+
 from __future__ import (
     print_function,
     absolute_import,

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,3 +1,20 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# NOTICE:
+# modified by elrandira to support commas for index accesses and steps in slices
+# https://github.com/h2non/jsonpath-ng/pull/102
+
 import doctest
 from collections import namedtuple
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,3 +1,20 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# NOTICE:
+# modified by elrandira to support commas for index accesses
+# https://github.com/h2non/jsonpath-ng/pull/102
+
 import pytest
 
 from jsonpath_ng.ext.filter import Filter, Expression

--- a/tests/test_jsonpath.py
+++ b/tests/test_jsonpath.py
@@ -1,3 +1,20 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# NOTICE:
+# modified by elrandira to support commas for index accesses and steps in slices
+# https://github.com/h2non/jsonpath-ng/pull/102
+
 from __future__ import unicode_literals, print_function, absolute_import, division, generators, nested_scopes
 import unittest
 

--- a/tests/test_jsonpath_rw_ext.py
+++ b/tests/test_jsonpath_rw_ext.py
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 #
+# NOTICE:
 # modified by dlacher to support predicate logic: https://github.com/h2non/jsonpath-ng/pull/21
 
 """

--- a/tests/test_jsonpath_rw_ext.py
+++ b/tests/test_jsonpath_rw_ext.py
@@ -11,6 +11,8 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+#
+# modified by dlacher to support predicate logic: https://github.com/h2non/jsonpath-ng/pull/21
 
 """
 test_jsonpath_ng_ext

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,3 +1,20 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# NOTICE:
+# modified by elrandira to support commas for index accesses
+# https://github.com/h2non/jsonpath-ng/pull/102
+
 from __future__ import unicode_literals, print_function, absolute_import, division, generators, nested_scopes
 import unittest
 


### PR DESCRIPTION
Since this is a custom version of the original h2non/jsonpath-ng repository, we need to add copyright notices to comply with the Apache 2.0 license.